### PR TITLE
Pass the redis prefix to the limiter after instantiating it

### DIFF
--- a/main.go
+++ b/main.go
@@ -153,6 +153,8 @@ func NewWithConfig(config Config) echo.MiddlewareFunc {
 	}
 
 	limiter := go_limiter.NewLimiter(config.Rediser)
+	limiter.Prefix = config.Prefix
+
 	limit := &go_limiter.Limit{
 		Period:    config.Period,
 		Algorithm: config.Algorithm,


### PR DESCRIPTION
The current version doesn't pass the redis key prefix to the base library. This PR fixes it.